### PR TITLE
Fix relog

### DIFF
--- a/server/sv_savecoordsdb.lua
+++ b/server/sv_savecoordsdb.lua
@@ -6,7 +6,7 @@ RegisterNetEvent('vorp:saveLastCoords', function(lastCoords, lastHeading)
 
     LastCoordsInCache[source] = {lastCoords, lastHeading}
     
-    local characterCoords = json.encode({x = math.floor(lastCoords.x)+0.0, y = math.floor(lastCoords.y)+0.0, z = math.floor(lastCoords.z)+0.0, heading = math.floor(lastHeading)+0.0})
+    local characterCoords = json.encode({x = round(lastCoords.x, 2), y = round(lastCoords.y, 2), z = round(lastCoords.z, 2), heading = round(lastHeading, 2)})
 
     _users[identifier].GetUsedCharacter().Coords(characterCoords)
 end)
@@ -19,3 +19,8 @@ RegisterNetEvent('vorp:ImDead', function(isDead)
         _users[identifier].GetUsedCharacter().setDead(isDead)
     end
 end)
+
+function round(number, decimals)
+    local power = 10^decimals
+    return math.floor(number * power) / power
+end


### PR DESCRIPTION
Round the coords for the database on 2 decimals.

If a player logout to close to a wall he sometine could spawn into the wall or under the map.
To round the values more exactly is fixing this issue